### PR TITLE
Add .wav to supported file uploads

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ const pads = Array.from({ length: 16 }, (_, i) => {
   const input = document.createElement("input");
   const button = document.createElement("button");
   input.setAttribute("type", "file");
-  input.setAttribute("accept", "audio/*");
+  input.setAttribute("accept", ".wav,audio/*");
   input.setAttribute("multiple", "");
   input.addEventListener("change", () => {
     if (input.files) {


### PR DESCRIPTION
Hi, I was looking for exactly for what your application does, but I faced weird issue when was trying to upload files from iPhone safari, I dived a bit into and added `.wav` support since it's not in the `audio/*` list. 

https://www.iana.org/assignments/media-types/media-types.xhtml#audio

Hope you don't mind merging it.  